### PR TITLE
1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iojs-bin",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "iojs",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I'm getting an error on osx:

``` bash
version not found: iojs-darwin-x64@1.2.0
```

I figure it should be updated to 1.2.0 but there may be issues with the darwin binary name?
