### PR TITLE
Add repository url to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,5 +11,9 @@
     "iojs": "node_modules/.bin/iojs"
   },
   "keywords": "mad science",
-  "license": "ISC"
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aredridel/iojs-bin"
+  }
 }


### PR DESCRIPTION
Removes an `npm` warning and allows people to use `npm repo` to get here :]
